### PR TITLE
fix: remove uuid conversion to bytes

### DIFF
--- a/src/Async/JobExecutionHandler.php
+++ b/src/Async/JobExecutionHandler.php
@@ -32,7 +32,7 @@ readonly class JobExecutionHandler
         try {
             $this->jobRunner->execute($message);
         } catch (\Throwable $e) {
-            $criteria = new Criteria([Uuid::fromHexToBytes($message->getJobId())]);
+            $criteria = new Criteria([$message->getJobId()]);
 
             $job = $this->jobRepository->search($criteria, Context::createDefaultContext())->first();
 


### PR DESCRIPTION
The `Criteria` constructor expects UUID to in hex and not in bytes. This leads to failed jobs to not be retried