### PR TITLE
ADS-5332 Job display starts as list

### DIFF
--- a/src/Resources/app/administration/src/module/nosto-job/page/nosto-job-listing-index/page.js
+++ b/src/Resources/app/administration/src/module/nosto-job/page/nosto-job-listing-index/page.js
@@ -58,7 +58,7 @@ export default {
             groupCreationDate: {
             },
             sortType: 'status',
-            jobDisplayType: null,
+            jobDisplayType: 'list',
             autoLoad: false,
             autoLoadIsActive: false,
             autoReloadInterval: 60000,
@@ -188,7 +188,6 @@ export default {
 
     methods: {
         createdComponent() {
-            this.jobDisplayType = 'list';
             this.getList();
         },
 


### PR DESCRIPTION
- Job display type starts now as list immediately instead of starting as null
- Removed redundant assignment